### PR TITLE
F-1070-1 Cuando hay dos proyectos con actividades de marco lógico del mismo tipo, si se añade a uno, queda añadida a ambas, pero no puede borrarse de una sola.

### DIFF
--- a/app/assets/javascripts/cor1440_gen/motor.js.coffee
+++ b/app/assets/javascripts/cor1440_gen/motor.js.coffee
@@ -95,24 +95,25 @@ cor1440_gen_rangoedadc_todos = () ->
       $(this).find('select[id$=actividadpf_ids]').val(ac_relacionadas)
       $(this).find('select[id$=actividadpf_ids]').trigger('chosen:updated')
     )
-@cor1440_gen_actividad_actualiza_mismotipo = (root) ->
-  acids = ['']
-  $('select[id^=actividad_actividad_proyectofinanciero_attributes_][id$=_actividadpf_ids]').each( () -> 
-    t = $(this)
-    if t.parent().parent().parent().not(':hidden').length > 0
-      acids = acids.concat(t.val())
-  )
-  prids = []
-  $('#actividad_proyectofinanciero tr').not(':hidden').each(() -> 
-    idex = $(this).find('select[id$=proyectofinanciero_id]').val()
-    prids.push(idex) 
-  )
-  params = {
-    actividadpf_ids: acids,
-    proyectofinanciero_ids: prids
-  }
-  sip_ajax_recibe_json(root, 'api/actividades/relacionadas', 
-    params, cor1440_gen_llena_actividadpf_relacionadas)
+@cor1440_gen_actividad_actualiza_mismotipo = (root, res) ->
+  if res.selected?
+    acids = ['']
+    $('select[id^=actividad_actividad_proyectofinanciero_attributes_][id$=_actividadpf_ids]').each( () -> 
+      t = $(this)
+      if t.parent().parent().parent().not(':hidden').length > 0
+        acids = acids.concat(t.val())
+    )
+    prids = []
+    $('#actividad_proyectofinanciero tr').not(':hidden').each(() -> 
+      idex = $(this).find('select[id$=proyectofinanciero_id]').val()
+      prids.push(idex) 
+    )
+    params = {
+      actividadpf_ids: acids,
+      proyectofinanciero_ids: prids
+    }
+    sip_ajax_recibe_json(root, 'api/actividades/relacionadas', 
+      params, cor1440_gen_llena_actividadpf_relacionadas)
 # Actualiza campos dinámicos cuando hay una tabla de proyectofinanciero
 # y actividades de proyectofinanciero
 @cor1440_gen_actividad_actualiza_camposdinamicos2 = (root) ->
@@ -457,7 +458,7 @@ cor1440_gen_rangoedadc_todos = () ->
     # Tras agregar o eliminar actividades de convenio a un convenio
     # agregare o eliminar subformularios asociados
     $(document).on('change', 'select[id^=actividad_actividad_proyectofinanciero_attributes_][id$=actividadpf_ids]', (e, res) ->
-      cor1440_gen_actividad_actualiza_mismotipo(root)
+      cor1440_gen_actividad_actualiza_mismotipo(root, res)
       cor1440_gen_actividad_actualiza_camposdinamicos2(root)
     )
  


### PR DESCRIPTION
Pruebas: 
Primero se intentó cambiar el método change por otro que no incluyera eliminar los ítems. después se detectó las propiedades selected y desdeslected, y se agregó validación. Probado eliminando actividad agregadas del mismo tipo y actividad unitaria.  